### PR TITLE
Add issue template for new ontology term #13

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-ontology-term.md
+++ b/.github/ISSUE_TEMPLATE/new-ontology-term.md
@@ -1,0 +1,35 @@
+---
+name: "New ontology term"
+about: For including new terms into the ontology
+title: Your title should make sense if said after "The issue is <your issue title>"
+labels: "new term, To do"
+assignees: ''
+
+---
+
+## Template Instructions
+
+Please fill out as much of the list below as you can for each entity you wish to suggest for inclusion in CEPO. It isn't mandatory to complete every bullet point, but the more information is provided, the easier it will be for other developers to evaluate your suggestion.
+
+## Proposed New Ontology Entity
+
+- **Proposed Label**: [The primary term that is used to refer to the entity. Please follow the ENERO Foundry principle on [Naming Conventions](https://enerofoundry.github.io/ENEROFoundry/principles/8_naming/).]
+- **Potential Synonyms**: [Any alternative terms that can also be used to refer to the entity. Please follow the ENERO Foundry principle on [Naming Conventions](https://enerofoundry.github.io/ENEROFoundry/principles/8_naming/).]
+- **Proposed Superclass**: [an existing term in CEPO]
+- **Proposed Definition**: A [proposed entity] is a [proposed superclass] that is [specify what distinguishes the proposed entity from other entities of this kind]. [Please refer to the ENERO Foundry principle on [Textual Definitions](https://enerofoundry.github.io/ENEROFoundry/principles/9_definitions/).]
+- **Definition Sources/References**: [links to any reference material that can help others better understand the entity]
+- **Other Information**:
+    - What differentiates the proposed entity from other entities of the proposed superclass?
+    - What would be an example of usage/instance of this entity?
+    - What are potential subclasses of the proposed entity?
+
+## Workflow checklist
+
+- [ ] I discussed the issue with someone else than me before working on a solution
+- [ ] I already read the **latest** version of the [workflow](https://github.com/OpenEnergyPlatform/ClimateEnergyPolicyOntology/blob/production/CONTRIBUTING.md) for this repository
+- [ ] The [goal](https://github.com/OpenEnergyPlatform/ClimateEnergyPolicyOntology/blob/production/README.rst) of this ontology is clear to me 
+
+I am aware that
+- [ ] every entry in the ontology should have a definition
+- [ ] classes should arise from concepts rather than from words
+- [ ] any ontology content that is proposed in this issue may be altered as needed to fit the structure and conventions of CEPO


### PR DESCRIPTION
created a template for suggestions of new terms for CEPO (used the OEO new term issue template as a base)

## Type of change (CHANGELOG.md)

### Added
- Issue template file `new-ontology-term.md` [(#21)](https://github.com/OpenEnergyPlatform/climate-energy-policy-ontology/pull/21)

## Workflow checklist

### Automation

Part of #13

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/ClimateEnergyPolicyOntology/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/ClimateEnergyPolicyOntology/blob/develop/CHANGELOG.md)
- [x] 📙 Update the documentation
- [x] 🐙 Assign a reviewer to the PR

### Reviewer

- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/ClimateEnergyPolicyOntology/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
